### PR TITLE
Discord embed color settings for join, leave and switch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+.idea
 **/build/
 !src/**/build/
 

--- a/ProxyMessagesVelocity/bin/default/velocity-plugin.json
+++ b/ProxyMessagesVelocity/bin/default/velocity-plugin.json
@@ -1,1 +1,1 @@
-{"id":"proxymessages","name":"ProxyMessages","version":"2.2.0","description":"A message system for servers to interact over a proxy.","authors":["BlackDiamond"],"dependencies":[],"main":"dev.ogblackdiamond.proxymessages.ProxyMessages"}
+{"id":"proxymessages","name":"ProxyMessages","version":"2.3.0","description":"A message system for servers to interact over a proxy.","authors":["BlackDiamond"],"dependencies":[],"main":"dev.ogblackdiamond.proxymessages.ProxyMessages"}

--- a/ProxyMessagesVelocity/build.gradle.kts
+++ b/ProxyMessagesVelocity/build.gradle.kts
@@ -43,6 +43,6 @@ tasks.jar {
 tasks.shadowJar {
     archiveBaseName.set("ProxyMessagesVelocity")
     archiveClassifier.set("")
-    archiveVersion.set("2.2.0")
+    archiveVersion.set("2.3.0")
     minimize()
 }

--- a/ProxyMessagesVelocity/src/main/java/dev/ogblackdiamond/proxymessages/ProxyMessages.java
+++ b/ProxyMessagesVelocity/src/main/java/dev/ogblackdiamond/proxymessages/ProxyMessages.java
@@ -150,7 +150,7 @@ public class ProxyMessages {
                 event.getPreviousServer() == null ? "join" : "switch",
                 player.getUsername(),
                 previousServerNull ? "" : event.getPreviousServer().getServerInfo().getName(),
-                previousServerNull ? "" : player.getCurrentServer().get().getServerInfo().getName(),
+                player.getCurrentServer().get().getServerInfo().getName(),
                 message
             ),
             event.getPlayer().getUniqueId()
@@ -174,7 +174,7 @@ public class ProxyMessages {
             messageUtil.compileFormattedMessage(
                 "leave",
                 player.getUsername(),
-                "",
+                player.getCurrentServer().get().getServerInfo().getName(),
                 "",
                 leaveMessageOptions.get((int) (Math.random() * leaveMessageOptions.size()))
             ),

--- a/ProxyMessagesVelocity/src/main/java/dev/ogblackdiamond/proxymessages/ProxyMessages.java
+++ b/ProxyMessagesVelocity/src/main/java/dev/ogblackdiamond/proxymessages/ProxyMessages.java
@@ -34,7 +34,7 @@ import org.spongepowered.configurate.yaml.YamlConfigurationLoader;
 /**
  * Main class for ProxyMessages.
  */
-@Plugin(id = "proxymessages", name = "ProxyMessages", version = "2.2.0", 
+@Plugin(id = "proxymessages", name = "ProxyMessages", version = "2.3.0",
     description = "A message system for servers to interact over a proxy.", 
     authors = {"BlackDiamond"})
 public class ProxyMessages {
@@ -192,6 +192,6 @@ public class ProxyMessages {
                 srvr.sendMessage(message.getComponent());
             }
         }
-        if (discordUtil != null) discordUtil.playerNotification(message.getString(), uuid);
+        if (discordUtil != null) discordUtil.playerNotification(message, uuid);
     }
 }

--- a/ProxyMessagesVelocity/src/main/java/dev/ogblackdiamond/proxymessages/util/MessageUtil.java
+++ b/ProxyMessagesVelocity/src/main/java/dev/ogblackdiamond/proxymessages/util/MessageUtil.java
@@ -25,7 +25,7 @@ public class MessageUtil {
         // builds the final component, interpolating the correct strings when need 
         switch (type) {
             
-            case "join": 
+            case "join":
             case "leave": {
                 
                 for (int i = 0; i < messageLength; i++) {
@@ -83,23 +83,26 @@ public class MessageUtil {
             default: {
                 return new MessageReturns(
                     Component.text("[ProxyMessages] Invalid type passed! Cannot render message.").color(NamedTextColor.RED),
-                    "[ProxyMessages] Invalid type passed! Cannot render message."
+                    "[ProxyMessages] Invalid type passed! Cannot render message.",
+                        "other"
                 );
             }
 
         }
 
-        return new MessageReturns(finalMessage.build(), finalString); 
+        return new MessageReturns(finalMessage.build(), finalString, type);
     }
 
     public class MessageReturns {
 
         Component component;
         String string;
+        String type;
 
-        public MessageReturns(Component component, String string) {
+        public MessageReturns(Component component, String string, String type) {
             this.component = component;
             this.string = string;
+            this.type = type;
         }
 
         public Component getComponent() {

--- a/ProxyMessagesVelocity/src/main/java/dev/ogblackdiamond/proxymessages/util/MessageUtil.java
+++ b/ProxyMessagesVelocity/src/main/java/dev/ogblackdiamond/proxymessages/util/MessageUtil.java
@@ -32,6 +32,8 @@ public class MessageUtil {
 
                     boolean atLength = i + playerNameLength > messageLength;
                     boolean atColorLength = i + colorLength > messageLength;
+                    boolean newServerLength = i + newServerNameLength > messageLength;
+                    boolean previousServerLength = i + previousServerNameLength > messageLength;
 
                     if (!atColorLength && chosenMessage.substring(i, i + 2).equals("{#")) {
                         textColor = TextColor.fromCSSHexString(chosenMessage.substring(i + 1, i + colorLength - 1));
@@ -40,6 +42,14 @@ public class MessageUtil {
                         finalMessage.append(Component.text(playerName).color(textColor).decoration(TextDecoration.BOLD, true));
                         finalString += playerName;
                         i += playerNameLength - 1;
+                    } else if (!previousServerLength && chosenMessage.substring(i, i + previousServerNameLength).equals("{prev}")) {
+                        finalMessage.append(Component.text(previousServer).color(textColor).decoration(TextDecoration.BOLD, true));
+                        finalString += previousServer;
+                        i += previousServerNameLength - 1;
+                    } else if (!newServerLength && chosenMessage.substring(i, i + newServerNameLength).equals("{cur}")) {
+                        finalMessage.append(Component.text(newServer).color(textColor).decoration(TextDecoration.BOLD, true));
+                        finalString += newServer;
+                        i += newServerNameLength - 1;
                     } else {
                         finalMessage.append(Component.text(chosenMessage.substring(i, i+1)).color(textColor).decoration(TextDecoration.BOLD, false));
                         finalString += chosenMessage.substring(i, i+1);

--- a/ProxyMessagesVelocity/src/main/resources/config.yml
+++ b/ProxyMessagesVelocity/src/main/resources/config.yml
@@ -32,6 +32,14 @@ discord:
   enabled: false 
   bot-token: "{token}"
   channel-id: "{channel-id}"
+
+  # Color of the discord embed for join messages
+  join-color: "#00ff00"
+  # Color of the discord embed for leave messages
+  leave-color: "#ff0000"
+  # Color of the discord embed for switch messages
+  switch-color: "#ffff00"
+
   # all text options support markdown formatting
   # these messages DO NOT support the hex codes like above
   text-configuration:
@@ -42,5 +50,4 @@ discord:
     server-count: true
 
     # on startup and shutdown, show an image if you provided one
-    display-icon: false 
-
+    display-icon: false

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Under the `discord` section of your `config.yml`:
 
 * `bot-token`: A string that represents the bot token that the plugin will attempt to connect to. This is the same as the one you might use in the DiscordSRV plugin.
 * `channel-id`: The ID of the channel you want the proxy messages to be sent to.
-
+* `join-color`: Hex color code to be used for the Discord embed for join messages.
+* `leave-color`: Hex color code to be used for the Discord embed for leave messages.
+* `switch-color`: Hex color code to be used for the Discord embed for switch messages.
 * `text-configuration`: Options to customize the messages that get sent. Text options support markdown formatting.
   * `online-message`: The message to be sent when the proxy boots up.
   * `offline-message`: The message to be sent when the proxy shuts down.


### PR DESCRIPTION
Tested on my server and works as expected:
![image](https://github.com/user-attachments/assets/701e2cd5-5d24-4a14-a85b-de12e6d2c5cd)

- Version bump to 2.3.0
- Update playerNotification() to take entire Messageutil.MessageReturns message allowing to determine type also allows for easier support of future message types
- Load colors from config or set to default colors in DiscordUtil
- New function to validate that hex code from config.yml is valid
- Removed unused imports (my IDE did this automatically)
- Add IntelliJ IDEA project folder to gitignore
- Update README.md to include info on new config file values